### PR TITLE
Update docstrings to allow classes, throw error on missing method

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -48,9 +48,9 @@ helpers do
     contents = file.read
 
     # Get Docstring
-    docstring_regex = /def #{method}\([^\)]*\):\s*"""([\s\S]*?)"""/
+    docstring_regex = /(?:class|def) #{method}\([^\)]*\):\s*"""([\s\S]*?)"""/
     match = contents.match(docstring_regex)
-    return '' unless match
+    raise ArgumentError, "Couldn't find docstring for '#{method}'" unless match
     docstring = match[1]
 
     # Clean Docstring


### PR DESCRIPTION
@peter-at-bauxy looks like we only had docstrings for methods, not classes. I also went ahead and added an error message if it couldn't find any matching docstrings.
